### PR TITLE
Update Wikipedia protocol to https

### DIFF
--- a/src/http-status.coffee
+++ b/src/http-status.coffee
@@ -20,7 +20,7 @@ module.exports = (robot) ->
   robot.respond /http status (.*)/i, (msg) ->
     httpCode = msg.match[1]
     msg
-      .http('http://en.wikipedia.org/wiki/List_of_HTTP_status_codes')
+      .http('https://en.wikipedia.org/wiki/List_of_HTTP_status_codes')
       .get() (err, res, body) ->
           $ = cheerio.load(body)
           statusCode = $('#'+httpCode).parent().text()


### PR DESCRIPTION
Perhaps ironically, we were getting a 301 status code forwarding to https, resulting in an empty body initially.
