### PR TITLE
Add optional S to http

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-http-status",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Returns HTTP status/error code definitions from wikipedia.",
   "main": "index.coffee",
   "scripts": {

--- a/src/http-status.coffee
+++ b/src/http-status.coffee
@@ -17,8 +17,8 @@
 cheerio = require 'cheerio'
 
 module.exports = (robot) ->
-  robot.respond /http status (.*)/i, (msg) ->
-    httpCode = msg.match[1]
+  robot.respond /http(s?) status (.*)/i, (msg) ->
+    httpCode = msg.match[2]
     msg
       .http('https://en.wikipedia.org/wiki/List_of_HTTP_status_codes')
       .get() (err, res, body) ->

--- a/test/http-status_test.coffee
+++ b/test/http-status_test.coffee
@@ -15,5 +15,8 @@ describe 'http-status', ->
       send: sinon.spy()
     @http_status = http_status_module(@robot)
 
-  it 'responds to status code', ->
+  it 'responds to http status code', ->
     expect(@robot.respond).to.have.been.calledWith(/http status (.*)/i)
+  
+  it 'responds to https status code', ->
+    expect(@robot.respond).to.have.been.calledWith(/https status (.*)/i)


### PR DESCRIPTION
When checking for a status code I found myself being so used to https (GG Google) resulting in automagically typing the s after https. Damned. http.

So I've added `(s?)` to make sure it works both ways.

**What has been done**
- [x] Added (s?) regex
- [x] Added test
- [x] Increment version number
